### PR TITLE
feat(toc): support gitlab style toc comments

### DIFF
--- a/Markdown2Pdf.Demo/README.md
+++ b/Markdown2Pdf.Demo/README.md
@@ -4,7 +4,7 @@ This is a demo of all the Markdown2Pdf features.
 
 ## Table of Contents <!-- omit from toc -->
 
-<!--TOC-->
+[TOC]
 
 ## Common Markdown Functionality
 

--- a/Markdown2Pdf.Tests/TestFiles/README.md
+++ b/Markdown2Pdf.Tests/TestFiles/README.md
@@ -130,4 +130,4 @@ C -->|Three| F[Car]
 
 ## <img src="md2pdf.png" alt="Logo" Width=64px/> ._-This - is a &@! heading __ with . and ! -
 
-<!--TOC-->
+[TOC]

--- a/Markdown2Pdf/Markdown2PdfConverter.cs
+++ b/Markdown2Pdf/Markdown2PdfConverter.cs
@@ -181,12 +181,11 @@ public class Markdown2PdfConverter {
   }
 
   internal string GenerateHtml(string markdownContent) {
-    var toc = (TableOfContentsCreator?)null;
-    var tocHtml = string.Empty;
-    
     if (this.Options.TableOfContents != null) {
-      toc = new(this.Options.TableOfContents);
-      tocHtml = toc.ToHtml(markdownContent);
+      var toc = new TableOfContentsCreator(this.Options.TableOfContents);
+      var tocHtml = toc.ToHtml(markdownContent);
+      File.WriteAllText("test.md", markdownContent);
+      toc.InsertInto(ref markdownContent, tocHtml);
     }
 
     var pipeline = new MarkdownPipelineBuilder()
@@ -195,7 +194,6 @@ public class Markdown2PdfConverter {
       .Build();
 
     var htmlContent = Markdown.ToHtml(markdownContent, pipeline);
-    toc?.InsertInto(ref htmlContent, tocHtml);
 
     var templateModel = this._CreateTemplateModel(htmlContent);
 

--- a/Markdown2Pdf/Options/TableOfContentsOptions.cs
+++ b/Markdown2Pdf/Options/TableOfContentsOptions.cs
@@ -4,7 +4,7 @@ namespace Markdown2Pdf.Options;
 
 /// <summary>
 /// Options to create a Table of Contents for the PDF, generated from all headers. 
-/// The TOC will be inserted into all <c>&lt;!--TOC--&gt;</c> comments within the markdown document. 
+/// The TOC will be inserted into all <c>[TOC]</c>, <c>[[_TOC_]]</c> or <c>&lt;!-- toc --&gt;</c> comments within the markdown document. 
 /// </summary>
 public class TableOfContentsOptions {
 

--- a/Markdown2Pdf/Services/TableOfContentsCreator.cs
+++ b/Markdown2Pdf/Services/TableOfContentsCreator.cs
@@ -24,13 +24,15 @@ internal class TableOfContentsCreator(TableOfContentsOptions options) {
   private readonly int _minDepthLevel = options.MinDepthLevel -1;
   private readonly int _maxDepthLevel = options.MaxDepthLevel -1;
 
-  private const string _IDENTIFIER = "<!--TOC-->";
   private const string _OMIT_IN_TOC_IDENTIFIER = "<!-- omit from toc -->";
   private const string _HTML_CLASS_NAME = "table-of-contents";
+
   private static readonly Regex _headerReg = new("^(?<hashes>#{1,6}) +(?<title>[^\r\n]*)",
     RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.ExplicitCapture);
   private static readonly Regex _htmlElementReg = new("<[^>]*>[^>]*</[^>]*>|<[^>]*/>", RegexOptions.Compiled);
   private static readonly Regex _emojiReg = new(":(\\w+):", RegexOptions.Compiled);
+  private static readonly Regex _insertionRegex = new("""^(\[TOC]|\[\[_TOC_]]|<!-- toc -->)\r?$""",
+    RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Multiline);
 
   private IEnumerable<Link> _CreateLinks(string markdownContent) {
     var matches = _headerReg.Matches(markdownContent);
@@ -115,7 +117,7 @@ internal class TableOfContentsCreator(TableOfContentsOptions options) {
     return tocBuilder.ToString();
   }
 
-  internal void InsertInto(ref string htmlContent, string tocHtml)
-    => htmlContent = htmlContent.Replace(_IDENTIFIER, tocHtml);
+  internal void InsertInto(ref string content, string tocHtml)
+    => content = _insertionRegex.Replace(content, tocHtml);
 
 }

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ var converter = new Markdown2PdfConverter(options);
 | `IsLandscape`                 | Paper orientation.                                                                                                                                       | `false`                     |
 | `Format`                      | The paper format for the PDF.                                                                                                                            | `A4`                        |
 | `Scale`                       | Scale of the content. Must be between 0.1 and 2.                                                                                                         | `1`                         |
-| `TableOfContents`             | Creates a TOC out of the markdown headers and writes it into `<!--TOC-->` comments within the markdown document. [More Information](#table-of-contents). | `null`                      |
+| `TableOfContents`             | Creates a TOC from the markdown headers. [More Information](#table-of-contents).                                                                         | `null`                      |
 
 ## Header and Footer
 
@@ -76,7 +76,19 @@ options.CustomHeadContent = "<style>h1, h2, h3 { page-break-before: always; }</s
 
 ## Table of contents
 
-To add a table of contents insert `<!--TOC-->` into the markdown file and use the `Markdown2PdfOptions.TableOfContents` option.
+To add a table of contents insert
+* `[TOC]` (Gitlab Syntax)
+* `[[_TOC_]]` (Gitlab Syntax)
+* or `<!-- toc -->` (Comment)
+
+into the markdown document and use the `Markdown2PdfOptions.TableOfContents` option:
+
+```md
+# My Document
+
+[TOC]
+...
+```
 
 Example creating a TOC:
 


### PR DESCRIPTION
See https://docs.gitlab.com/ee/user/markdown.html#table-of-contents

Support the following tags
* [[\_TOC\_]]
* [TOC]
* ~~&lt;!--TOC--&gt;~~ instead: &lt;!-- toc --&gt;

> The support for these tags is case-insensitive