### PR TITLE
Save pdf file with a different name or location than given by the markdown file

### DIFF
--- a/Markdown2Pdf.Tests/Tests/PdfTests.cs
+++ b/Markdown2Pdf.Tests/Tests/PdfTests.cs
@@ -29,10 +29,10 @@ public class PdfTests {
     });
   }
 
-  private static object?[] _GetTestCasesHeaderFooter() => new object?[] {
+  private static object?[] _GetTestCasesHeaderFooter() => [
       new [] { File.ReadAllText(Utils.headerFile), null, "Header Text" },
       new [] { null, File.ReadAllText(Utils.footerFile), "Page 1/1" },
-    };
+    ];
 
   [Test]
   [TestCaseSource(nameof(_GetTestCasesHeaderFooter))]
@@ -126,18 +126,17 @@ public class PdfTests {
     });
   }
 
-  private static object?[] _GetTestCasesPdfPath() => new object?[] {
-      new [] { Utils.helloWorldFile.Replace("helloworld.md", "myhello.pdf"), },
-      new [] { Utils.helloWorldFile.Replace("helloworld.md",Path.Combine("test", "myhello.pdf")), },
-    };
-
+  private static object[] _GetTestCasesPdfPath() => [
+      new [] { Path.Combine(Utils.tempDir.FullName, "myhello.pdf") },
+      new [] { Path.Combine(Utils.tempDir.FullName, "test", "myhello.pdf") },
+    ];
 
   [Test]
   [TestCaseSource(nameof(_GetTestCasesPdfPath))]
-  public async Task TestGeneratesPdfDifferentPath(string? targetFile) {
+  public async Task TestGeneratesPdfAtDifferentPath(string targetFile) {
     // arrange
     var converter = new Markdown2PdfConverter();
-    
+
     // act
     var pdfPath = await converter.Convert(Utils.helloWorldFile, targetFile);
 
@@ -151,7 +150,7 @@ public class PdfTests {
 
   [Test]
   [TestCaseSource(nameof(_GetTestCasesPdfPath))]
-  public async Task TestCombineTwoFilesDifferentPath(string? targetFile) {
+  public async Task TestCombinesTwoFilesAtDifferentPath(string targetFile) {
     // arrange
     var markdownList = new List<string>() { Utils.helloWorldFile, Utils.readmeFile };
     var converter = new Markdown2PdfConverter();

--- a/Markdown2Pdf.Tests/Tests/PdfTests.cs
+++ b/Markdown2Pdf.Tests/Tests/PdfTests.cs
@@ -132,9 +132,9 @@ public class PdfTests {
     };
 
 
-    [Test]
-    [TestCaseSource(nameof(_GetTestCasesPdfPath))]
-    public async Task TestGeneratesPdfDifferentPath(string? targetFile) {
+  [Test]
+  [TestCaseSource(nameof(_GetTestCasesPdfPath))]
+  public async Task TestGeneratesPdfDifferentPath(string? targetFile) {
     // arrange
     var converter = new Markdown2PdfConverter();
     
@@ -146,6 +146,24 @@ public class PdfTests {
       Assert.That(pdfPath, Is.EqualTo(targetFile));
       Assert.That(File.Exists(pdfPath));
       Assert.That(Utils.PdfContains(pdfPath, "Hello World!"));
+    });
+  }
+
+  [Test]
+  [TestCaseSource(nameof(_GetTestCasesPdfPath))]
+  public async Task TestCombineTwoFilesDifferentPath(string? targetFile) {
+    // arrange
+    var markdownList = new List<string>() { Utils.helloWorldFile, Utils.readmeFile };
+    var converter = new Markdown2PdfConverter();
+
+    // act
+    var pdfPath = await converter.Convert(markdownList, targetFile);
+
+    // assert
+    Assert.Multiple(() => {
+      Assert.That(pdfPath, Is.EqualTo(targetFile));
+      Assert.That(Utils.PdfContains(pdfPath, "Hello World!"));
+      Assert.That(Utils.PdfContains(pdfPath, "Common Markdown Functionality"));
     });
   }
   [TearDown]

--- a/Markdown2Pdf.Tests/Tests/PdfTests.cs
+++ b/Markdown2Pdf.Tests/Tests/PdfTests.cs
@@ -29,13 +29,13 @@ public class PdfTests {
     });
   }
 
-  private static object?[] _GetTestCases() => new object?[] {
+  private static object?[] _GetTestCasesHeaderFooter() => new object?[] {
       new [] { File.ReadAllText(Utils.headerFile), null, "Header Text" },
       new [] { null, File.ReadAllText(Utils.footerFile), "Page 1/1" },
     };
 
   [Test]
-  [TestCaseSource(nameof(_GetTestCases))]
+  [TestCaseSource(nameof(_GetTestCasesHeaderFooter))]
   public async Task TestHeaderFooter2(string? headerContent, string? footerContent, string expected) {
     // arrange
     var options = new Markdown2PdfOptions {
@@ -126,6 +126,28 @@ public class PdfTests {
     });
   }
 
+  private static object?[] _GetTestCasesPdfPath() => new object?[] {
+      new [] { Utils.helloWorldFile.Replace("helloworld.md", "myhello.pdf"), },
+      new [] { Utils.helloWorldFile.Replace("helloworld.md",Path.Combine("test", "myhello.pdf")), },
+    };
+
+
+    [Test]
+    [TestCaseSource(nameof(_GetTestCasesPdfPath))]
+    public async Task TestGeneratesPdfDifferentPath(string? targetFile) {
+    // arrange
+    var converter = new Markdown2PdfConverter();
+    
+    // act
+    var pdfPath = await converter.Convert(Utils.helloWorldFile, targetFile);
+
+    // assert
+    Assert.Multiple(() => {
+      Assert.That(pdfPath, Is.EqualTo(targetFile));
+      Assert.That(File.Exists(pdfPath));
+      Assert.That(Utils.PdfContains(pdfPath, "Hello World!"));
+    });
+  }
   [TearDown]
   public void Teardown() => Utils.tempDir.Delete(true);
 

--- a/Markdown2Pdf/Markdown2PdfConverter.cs
+++ b/Markdown2Pdf/Markdown2PdfConverter.cs
@@ -187,7 +187,6 @@ public class Markdown2PdfConverter : IConvertionEvents {
       File.Delete(htmlPath);
   }
 
-
   internal string GenerateHtml(string markdownContent) {
     var markdownArgs = new MarkdownArgs(ref markdownContent);
     this._beforeMarkdownConversion?.Invoke(this, markdownArgs);

--- a/Markdown2Pdf/Markdown2PdfConverter.cs
+++ b/Markdown2Pdf/Markdown2PdfConverter.cs
@@ -126,6 +126,7 @@ public class Markdown2PdfConverter : IConvertionEvents {
   /// <summary>
   /// Converts the given enumerable of markdown-files to PDF.
   /// </summary>
+  /// <param name="markdownFilePaths">Enumerable with paths to the markdown files.</param>
   /// <remarks>The PDF will be saved in the same location of the first markdown file with the naming convention "markdownFileName.pdf".</remarks>
   public async Task<string> Convert(IEnumerable<string> markdownFilesPath) {
     var first = markdownFilesPath.First();
@@ -142,12 +143,16 @@ public class Markdown2PdfConverter : IConvertionEvents {
   /// </summary>
   /// <param name="markdownFilePaths">Enumerable with paths to the markdown files.</param>
   /// <param name="outputFilePath">File path for saving the PDF to.</param>
-  public async Task Convert(IEnumerable<string> markdownFilePaths, string outputFilePath) {
+  public async Task<string> Convert(IEnumerable<string> markdownFilePaths, string outputFilePath) {
     var markdownContent = string.Join(Environment.NewLine, markdownFilePaths.Select(File.ReadAllText));
 
     var markdownFilePath = Path.GetFullPath(markdownFilePaths.First());
     outputFilePath = Path.GetFullPath(outputFilePath);
+    Directory.CreateDirectory(Path.GetDirectoryName(outputFilePath));
+
     await this._Convert(outputFilePath, markdownContent, markdownFilePath);
+
+    return outputFilePath;
   }
 
   /// <summary>

--- a/Markdown2Pdf/Markdown2PdfConverter.cs
+++ b/Markdown2Pdf/Markdown2PdfConverter.cs
@@ -110,14 +110,17 @@ public class Markdown2PdfConverter : IConvertionEvents {
   /// </summary>
   /// <param name="markdownFilePath">Path to the markdown file.</param>
   /// <param name="outputFilePath">File path for saving the PDF to.</param>
-  /// <remarks>The PDF will be saved in the same location as the markdown file with the naming convention "markdownFileName.pdf".</remarks>
-  public async Task Convert(string markdownFilePath, string outputFilePath) {
+  /// <remarks>The PDF will be saved in the location given from outputFilePath</remarks>
+  public async Task<string> Convert(string markdownFilePath, string outputFilePath) {
     markdownFilePath = Path.GetFullPath(markdownFilePath);
     outputFilePath = Path.GetFullPath(outputFilePath);
+    Directory.CreateDirectory(Path.GetDirectoryName(outputFilePath));
 
     var markdownContent = File.ReadAllText(markdownFilePath);
 
     await this._Convert(outputFilePath, markdownContent, markdownFilePath);
+
+    return outputFilePath;
   }
 
   /// <summary>

--- a/Markdown2Pdf/Markdown2PdfConverter.cs
+++ b/Markdown2Pdf/Markdown2PdfConverter.cs
@@ -110,7 +110,7 @@ public class Markdown2PdfConverter : IConvertionEvents {
   /// </summary>
   /// <param name="markdownFilePath">Path to the markdown file.</param>
   /// <param name="outputFilePath">File path for saving the PDF to.</param>
-  /// <remarks>The PDF will be saved in the location given from outputFilePath</remarks>
+  /// <remarks>The PDF will be saved at the path specified in <paramref name="outputFilePath"/>.</remarks>
   public async Task<string> Convert(string markdownFilePath, string outputFilePath) {
     markdownFilePath = Path.GetFullPath(markdownFilePath);
     outputFilePath = Path.GetFullPath(outputFilePath);
@@ -128,12 +128,12 @@ public class Markdown2PdfConverter : IConvertionEvents {
   /// </summary>
   /// <param name="markdownFilePaths">Enumerable with paths to the markdown files.</param>
   /// <remarks>The PDF will be saved in the same location of the first markdown file with the naming convention "markdownFileName.pdf".</remarks>
-  public async Task<string> Convert(IEnumerable<string> markdownFilesPath) {
-    var first = markdownFilesPath.First();
+  public async Task<string> Convert(IEnumerable<string> markdownFilePaths) {
+    var first = markdownFilePaths.First();
     var markdownDir = Path.GetDirectoryName(first);
     var outputFileName = Path.GetFileNameWithoutExtension(first) + ".pdf";
     var outputFilePath = Path.Combine(markdownDir, outputFileName);
-    await this.Convert(markdownFilesPath, outputFilePath);
+    await this.Convert(markdownFilePaths, outputFilePath);
 
     return outputFilePath;
   }


### PR DESCRIPTION
Be able to save the generated pdf file at different name or location than given by the markdown file or the given set of markdown files.