### PR TITLE
Upgrade PuppeteerSharp to Version 20.2.2 to fix Chrome error

### DIFF
--- a/Markdown2Pdf/Markdown2Pdf.csproj
+++ b/Markdown2Pdf/Markdown2Pdf.csproj
@@ -62,7 +62,7 @@
 	<ItemGroup>
 		<PackageReference Include="Markdig" Version="0.36.2" />
 		<PackageReference Include="PdfPig" Version="0.1.8" />
-		<PackageReference Include="PuppeteerSharp" Version="20.1.3" />
+		<PackageReference Include="PuppeteerSharp" Version="20.2.2" />
 		<PackageReference Include="YamlDotNet" Version="15.1.2" />
 	</ItemGroup>
 


### PR DESCRIPTION
With newer Chrome Verision the pdf creation fails (more specific: Error in Markdown2PdfConveter.cs, Task GeneratePdfAsync, line 337 -> ' = await page.GoToAsync("file:///" + htmlFilePath, WaitUntilNavigation.Networkidle2);')

Can be fixed by upgrading PuppeteerSharp to version 20.2.2

See #100 