### PR TITLE
Update to net10 and newest stable version of packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ name: test
 on: [push, pull_request, workflow_dispatch]
 env:
   # Specifies dotnet SDK Version
-  DOTNET_VERSION: '8.0.x'
+  DOTNET_VERSION: '10.0.x'
 
 jobs:
   ci:
@@ -32,7 +32,7 @@ jobs:
     # Runs any tests in the project
     - name: Test
       run: |
-        mkdir -p Markdown2Pdf.Tests/bin/Release/net8.0/ 
-        cp Markdown2Pdf/package.json Markdown2Pdf.Tests/bin/Release/net8.0
-        (cd Markdown2Pdf.Tests/bin/Release/net8.0; npm install)
+        mkdir -p Markdown2Pdf.Tests/bin/Release/net10.0/ 
+        cp Markdown2Pdf/package.json Markdown2Pdf.Tests/bin/Release/net10.0
+        (cd Markdown2Pdf.Tests/bin/Release/net10.0; npm install)
         dotnet test --configuration Release --no-restore --verbosity normal

--- a/.github/workflows/update-wiki.yml
+++ b/.github/workflows/update-wiki.yml
@@ -5,7 +5,7 @@ on:
             - main
 env:
   # Specifies dotnet SDK Version
-  DOTNET_VERSION: '8.0.x'
+  DOTNET_VERSION: '10.0.x'
 
 jobs:
   ci:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/Markdown2Pdf.Demo/bin/Debug/net8.0/Markdown2Pdf.Demo.dll",
+            "program": "${workspaceFolder}/Markdown2Pdf.Demo/bin/Debug/net10.0/Markdown2Pdf.Demo.dll",
             "args": [],
             "cwd": "${workspaceFolder}/Markdown2Pdf.Demo",
             "console": "internalConsole",

--- a/Markdown2Pdf.Demo/Markdown2Pdf.Demo.csproj
+++ b/Markdown2Pdf.Demo/Markdown2Pdf.Demo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -28,3 +28,4 @@
   </ItemGroup>
 
 </Project>
+

--- a/Markdown2Pdf.Demo/Markdown2Pdf.Demo.csproj
+++ b/Markdown2Pdf.Demo/Markdown2Pdf.Demo.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Markdown2Pdf.Tests\Markdown2Pdf.Tests.csproj" />
     <ProjectReference Include="..\Markdown2Pdf\Markdown2Pdf.csproj" />
   </ItemGroup>
 

--- a/Markdown2Pdf.Tests/Markdown2Pdf.Tests.csproj
+++ b/Markdown2Pdf.Tests/Markdown2Pdf.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -16,11 +16,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.14.0" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Markdown2Pdf.Tests/Tests/HtmlTests.cs
+++ b/Markdown2Pdf.Tests/Tests/HtmlTests.cs
@@ -30,7 +30,7 @@ public partial class HtmlTests {
   [Test]
   public async Task Should_Use_Modules([Values(
     "<mjx-math class=\"MJX-TEX\" aria-hidden=\"true\">",
-    "<div class=\"mermaid\" data-processed=\"true\">",
+    "<pre class=\"mermaid\" data-processed=\"true\">",
     "<span class=\"hljs-keyword\">public</span>"
     )] string expectedHtmlContent, [Values(true, false)] bool runLocally) {
     // Arrange

--- a/Markdown2Pdf.Tests/Tests/PdfTests.cs
+++ b/Markdown2Pdf.Tests/Tests/PdfTests.cs
@@ -129,8 +129,8 @@ public class PdfTests {
   }
 
   private static object[] _GetTestCasesPdfPath() => [
-      new [] { Path.Combine(Utils.tempDir.FullName, "myhello.pdf") },
-      new [] { Path.Combine(Utils.tempDir.FullName, "test", "myhello.pdf") },
+      (object)Path.Combine(Utils.tempDir.FullName, "myhello.pdf"),
+      (object)Path.Combine(Utils.tempDir.FullName, "test", "myhello.pdf"),
     ];
 
   [Test]
@@ -173,7 +173,7 @@ public class PdfTests {
   [TestCase("testDocumentTitle", null, "testDocumentTitle")]
   [TestCase(null, "myMetadataTitle", "myMetadataTitle")]
   [TestCase("testDocumentTitle", "myMetadataTitle", "myMetadataTitle")]
-  public async Task Should_Set_Pdf_Metadata(string documentTitle, string metadataTitle, string expectedTitle) {
+  public async Task Should_Set_Pdf_Metadata(string? documentTitle, string? metadataTitle, string expectedTitle) {
     // Arrange
 
     var options = new Markdown2PdfOptions {

--- a/Markdown2Pdf.Tests/setup.ps1
+++ b/Markdown2Pdf.Tests/setup.ps1
@@ -1,6 +1,6 @@
 # Run this before running the tests
 
-$targetDirectory = ".\bin\Debug\net8.0"
+$targetDirectory = ".\bin\Debug\net10.0"
 
 New-Item -ItemType Directory -Force -Path $targetDirectory | Out-Null
 Copy-Item -Path "..\Markdown2Pdf\package.json" -Destination $targetDirectory

--- a/Markdown2Pdf/Markdown2Pdf.csproj
+++ b/Markdown2Pdf/Markdown2Pdf.csproj
@@ -60,10 +60,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Markdig" Version="0.36.2" />
-		<PackageReference Include="PdfPig" Version="0.1.8" />
-		<PackageReference Include="PuppeteerSharp" Version="20.1.3" />
-		<PackageReference Include="YamlDotNet" Version="15.1.2" />
+		<PackageReference Include="Markdig" Version="1.3.2" />
+		<PackageReference Include="PdfPig" Version="0.1.15" />
+		<PackageReference Include="PuppeteerSharp" Version="25.3.3" />
+		<PackageReference Include="YamlDotNet" Version="18.1.0" />
 	</ItemGroup>
 
 </Project>

--- a/Markdown2Pdf/Services/TableOfContentsCreator.cs
+++ b/Markdown2Pdf/Services/TableOfContentsCreator.cs
@@ -131,8 +131,8 @@ internal class TableOfContentsCreator {
       var lines = _lineBreakRegex.Split(text);
       IEnumerable<Annotation> annotations = page.ExperimentalAccess.GetAnnotations();
 
-      // the invisible link rectanges in the TOC contains the link addresses and the desination page
-      // it is possible to extract both informations and link them to the TOC elements
+      // the invisible link rectangles in the TOC contains the link addresses and the destination page
+      // it is possible to extract both information and link them to the TOC elements
       foreach (Annotation annotation in annotations) {
         // check if it is a GoTo annotation and contains a link destination
         if (annotation.Action.Type != ActionType.GoTo

--- a/Markdown2Pdf/Services/TableOfContentsCreator.cs
+++ b/Markdown2Pdf/Services/TableOfContentsCreator.cs
@@ -129,7 +129,7 @@ internal class TableOfContentsCreator {
     foreach (var page in pdf.GetPages()) {
       var text = ContentOrderTextExtractor.GetText(page);
       var lines = _lineBreakRegex.Split(text);
-      IEnumerable<Annotation> annotations = page.ExperimentalAccess.GetAnnotations();
+      IEnumerable<Annotation> annotations = page.GetAnnotations();
 
       // the invisible link rectangles in the TOC contains the link addresses and the destination page
       // it is possible to extract both information and link them to the TOC elements


### PR DESCRIPTION
In order to run with .Net 10.0 (support of .Net 8.0 ends in November this year) an update for the packages is necessary.

Also fixes #100 